### PR TITLE
Add FASTQC to PitViper

### DIFF
--- a/PitViper/environment.yaml
+++ b/PitViper/environment.yaml
@@ -14,6 +14,7 @@ dependencies:
   - click=8.0.3
   - cmake
   - fastcluster=1.2.4
+  - fastqc=0.12.1
   - flask=2.0.2
   - gawk=5.1.0
   - git

--- a/PitViper/workflow/Snakefile
+++ b/PitViper/workflow/Snakefile
@@ -14,6 +14,7 @@ if config['bowtie_activate'] == 'True':
         include: "rules/mapping.smk"
 if "fastq" in tsv.columns or "bam" in tsv.columns:
     include: "rules/mageck_count.smk"
+include: "rules/fastqc.smk"
 include: "rules/annotation.smk"
 include: "rules/filtering.smk"
 include: "rules/mageck_mle.smk"

--- a/PitViper/workflow/rules/commons.smk
+++ b/PitViper/workflow/rules/commons.smk
@@ -133,6 +133,9 @@ def get_pipeline_outputs(wildcards):
     comparaisons = get_all_pairwise_comparisons()
     token = config['token']
     wanted_outputs.append(f"results/{config['token']}/Report.ipynb")
+    # If `fastq` or `bam` columns are present in the tsv file, we add "results/{token}/fastqc" to the list of outputs
+    if 'fastq' in samples_file.columns or 'bam' in samples_file.columns:
+        wanted_outputs.append(f"results/{config['token']}/fastqc")
     for comparaison in comparaisons:
         if (config['directional_scoring_method_activate'] == 'True'):
             wanted_outputs.append("results/{token}/directional_scoring_method/{treatment}_vs_{control}/{treatment}_vs_{control}_all-elements_directional_scoring_method.txt".format(token = token, treatment = comparaison['treatment'], control = comparaison['control']))

--- a/PitViper/workflow/rules/fastqc.smk
+++ b/PitViper/workflow/rules/fastqc.smk
@@ -1,0 +1,41 @@
+
+
+def getFastqcInput(wildcards):
+    sample_sheet = pd.read_csv(config['tsv_file'], sep="\t")
+    # If column 'fastq' is present, use it
+    path_to_files = []
+    if 'fastq' in sample_sheet.columns:
+        path_to_files = sample_sheet['fastq'].tolist()
+    # If column 'bam' is present, use it
+    elif 'bam' in sample_sheet.columns:
+        path_to_files = sample_sheet['bam'].tolist()
+    return path_to_files
+
+
+def getFastqcInputParams(wildcards):
+    sample_sheet = pd.read_csv(config['tsv_file'], sep="\t")
+    # If column 'fastq' is present, use it
+    path_to_files = []
+    if 'fastq' in sample_sheet.columns:
+        path_to_files = sample_sheet['fastq'].tolist()
+    # If column 'bam' is present, use it
+    elif 'bam' in sample_sheet.columns:
+        path_to_files = sample_sheet['bam'].tolist()
+    # Create a string with files separated by space
+    return " ".join(path_to_files)
+    
+
+rule fastqc:
+    input:
+        getFastqcInput
+    output:
+        directory(f"results/{config['token']}/fastqc")
+    params:
+        input=getFastqcInputParams
+    log:
+        f"logs/{config['token']}/fastqc.log"
+    shell:
+        """
+        mkdir -p {output} && \
+        fastqc -o {output} -t 10 {params.input} &> {log}
+        """


### PR DESCRIPTION
FASTQC is used if the design file contains a "fastq" or "bam" column name. FASTQC applies to all files present in this column. Results and logs are stored accordingly.